### PR TITLE
Fix some issues from different platforms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,55 @@
+# Prerequisites
+*.d
+
+# Object files
+*.o
+*.ko
+*.obj
+*.elf
+
+# Linker output
+*.ilk
+*.map
+*.exp
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Libraries
+*.lib
+*.a
+*.la
+*.lo
+
+# Shared objects (inc. Windows DLLs)
+*.dll
+*.so
+*.so.*
+*.dylib
+
+# Executables
+*.exe
+*.out
+*.app
+*.i*86
+*.x86_64
+*.hex
+
+# Debug files
+*.dSYM/
+*.su
+*.idb
+*.pdb
+
+# Kernel Module Compile Results
+*.mod*
+*.cmd
+.tmp_versions/
+modules.order
+Module.symvers
+Mkfile.old
+dkms.conf
+
+# vscode files
+.vscode

--- a/everlasting_framework.hpp
+++ b/everlasting_framework.hpp
@@ -37,7 +37,7 @@ namespace Button {
             return ray::CheckCollisionPointRec(pos, rect);
         }
         RectButton(int x = 0, int y = 0, int w = 0, int h = 0) {
-            rect = ray::Rectangle(x + (w / 2), y + (h / 2), w, h);
+            rect = ray::Rectangle{(float)(x + (w / 2)), (float)(y + (h / 2)), (float)w, (float)h};
             this->w = w;
             this->h = h;
             this->x = x;

--- a/everlasting_framework.hpp
+++ b/everlasting_framework.hpp
@@ -254,6 +254,6 @@ struct Context : ContextBase {
         windowFps = fps;
     }
     ~Context() {
-        ray::CloseWindow();
+        // ray::CloseWindow();
     }
 };


### PR DESCRIPTION
The behavior will not change from this PR.
The PR is intended to fix 2 bugs.

One of them is being the use of raylib's Rectangle struct as a class.
Some compilers allow usage of structs as classes, others don't.

The other bug is the raylib's CloseWindow function is being called 2 times.
One if from the "run" method of Context class and another is from the destructor of the Context class